### PR TITLE
feat: 최근 검색 이력 화면 UI 생성

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/java/com/ssafy/movie_search/present/views/MainActivity.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/MainActivity.kt
@@ -20,4 +20,12 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                 .commit()
         }
     }
+
+    fun startRecentSearchFragment() {
+        supportFragmentManager
+            .beginTransaction()
+            .replace(R.id.fl_main, RecentSearchFragment())
+            .addToBackStack(null)
+            .commit()
+    }
 }

--- a/app/src/main/java/com/ssafy/movie_search/present/views/MovieFragment.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/MovieFragment.kt
@@ -39,5 +39,9 @@ class MovieFragment : BaseFragment<FragmentMovieBinding>(R.layout.fragment_movie
                 Movie(null, "제목 : 아이", "출시 : 2021", "평점 : 0.00"),
                 Movie(null, "제목 : 아이", "출시 : 2021", "평점 : 0.00"))
         )
+
+        binding.btnMovieFRecentSearch.setOnClickListener {
+            (context as MainActivity).startRecentSearchFragment()
+        }
     }
 }

--- a/app/src/main/java/com/ssafy/movie_search/present/views/RecentSearchFragment.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/RecentSearchFragment.kt
@@ -1,0 +1,30 @@
+package com.ssafy.movie_search.present.views
+
+import android.os.Bundle
+import android.view.View
+import com.andback.pocketfridge.present.config.BaseFragment
+import com.google.android.material.chip.Chip
+import com.ssafy.movie_search.R
+import com.ssafy.movie_search.databinding.FragmentRecentSearchBinding
+
+class RecentSearchFragment : BaseFragment<FragmentRecentSearchBinding>(R.layout.fragment_recent_search) {
+    var test = 1
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initEvent()
+    }
+
+    private fun initEvent() {
+        binding.btnRecentSearchFTemp.setOnClickListener {
+            binding.cgRecentSearchF.addView(Chip(requireContext()).apply {
+                text = "${test++}번 chip"
+
+                setOnClickListener {
+                    showToastMessage("$text")
+                }
+            })
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_recent_search.xml
+++ b/app/src/main/res/layout/fragment_recent_search.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <Button
+            android:id="@+id/btn_recent_searchF_temp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="chip 만들기"
+            android:layout_gravity="center"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="@dimen/activity_margin_default"
+            android:text="최근 검색 이력"/>
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/cg_recent_searchF"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"/>
+    </LinearLayout>
+</layout>


### PR DESCRIPTION
## 개요
- Resolves #3
- 최근 검색 이력 화면 UI를 생성했습니다.
- 최근 검색한 키워드를 보여주는 방법으로 chip을 선택했습니다.

## 작업사항
- 아직 내부 DB가 구현되지 않았기 때문에 버튼을 누르면 chip을 생성하도록 임시로 구현해두었습니다.
- MovieFragment에서 RecentSearchFragment로 이동할 수 있게 구현해두었습니다.

## 구현화면

<img src="https://user-images.githubusercontent.com/76620764/167486502-ed42e4b2-a4ee-46ed-9e4c-b0283b191be5.jpg" height="600"/>