### PR TITLE
feat: 내부 DB 구현 및 최근 검색 이력 저장

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     // Room
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
-    implementation "androidx.room:room-rxjava2:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
 
     // For viewModels()
     implementation 'androidx.activity:activity-ktx:1.4.0'
@@ -97,5 +97,6 @@ dependencies {
     // Lottie
     implementation "com.airbnb.android:lottie:$lottie_version"
 
-
+    // Coroutine
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
 }

--- a/app/src/main/java/com/ssafy/movie_search/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/ssafy/movie_search/data/db/AppDatabase.kt
@@ -1,0 +1,11 @@
+package com.ssafy.movie_search.data.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.ssafy.movie_search.data.db.dao.RecentSearchDao
+import com.ssafy.movie_search.data.model.RecentSearchEntity
+
+@Database(entities = [RecentSearchEntity::class], version = 1)
+abstract class AppDatabase: RoomDatabase() {
+    abstract fun recentSearchDao(): RecentSearchDao
+}

--- a/app/src/main/java/com/ssafy/movie_search/data/db/dao/RecentSearchDao.kt
+++ b/app/src/main/java/com/ssafy/movie_search/data/db/dao/RecentSearchDao.kt
@@ -1,0 +1,20 @@
+package com.ssafy.movie_search.data.db.dao
+
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.ssafy.movie_search.data.model.RecentSearchEntity
+import com.ssafy.movie_search.present.utils.RECENT_SEARCH_TABLE
+
+@Dao
+interface RecentSearchDao {
+    @Insert()
+    fun write(recentSearchEntity: RecentSearchEntity)
+
+    @Query("SELECT * FROM $RECENT_SEARCH_TABLE")
+    fun readAll(): LiveData<List<RecentSearchEntity>>
+
+    @Query("DELETE FROM $RECENT_SEARCH_TABLE WHERE id IN (SELECT id FROM $RECENT_SEARCH_TABLE ORDER BY id ASC LIMIT 1) AND 10 = (SELECT COUNT(*) FROM $RECENT_SEARCH_TABLE)")
+    fun deleteLastItemIfOver10()
+}

--- a/app/src/main/java/com/ssafy/movie_search/data/di/LocalDataModule.kt
+++ b/app/src/main/java/com/ssafy/movie_search/data/di/LocalDataModule.kt
@@ -1,0 +1,41 @@
+package com.ssafy.movie_search.data.di
+
+import android.content.Context
+import androidx.room.Room
+import com.ssafy.movie_search.data.db.AppDatabase
+import com.ssafy.movie_search.data.db.dao.RecentSearchDao
+import com.ssafy.movie_search.data.repository.RecentSearch.RecentSearchLocalDataSource
+import com.ssafy.movie_search.data.repository.RecentSearch.RecentSearchLocalDataSourceImpl
+import com.ssafy.movie_search.present.utils.DB_NAME
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+class LocalDataModule {
+    @Provides
+    @Singleton
+    fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase {
+        return Room.databaseBuilder(
+            context,
+            AppDatabase::class.java,
+            DB_NAME
+        ).build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRecentSearchDao(appDatabase: AppDatabase): RecentSearchDao {
+        return appDatabase.recentSearchDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRecentSearchLocalDataSource(recentSearchDao: RecentSearchDao): RecentSearchLocalDataSource {
+        return RecentSearchLocalDataSourceImpl(recentSearchDao)
+    }
+}

--- a/app/src/main/java/com/ssafy/movie_search/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ssafy/movie_search/data/di/RepositoryModule.kt
@@ -2,7 +2,10 @@ package com.ssafy.movie_search.data.di
 
 import com.ssafy.movie_search.data.repository.Movie.MovieRemoteDataSource
 import com.ssafy.movie_search.data.repository.MovieRepositoryImpl
+import com.ssafy.movie_search.data.repository.RecentSearch.RecentSearchLocalDataSource
+import com.ssafy.movie_search.data.repository.RecentSearchRepositoryImpl
 import com.ssafy.movie_search.domain.repository.MovieRepository
+import com.ssafy.movie_search.domain.repository.RecentSearchRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -16,5 +19,11 @@ class RepositoryModule {
     @Singleton
     fun provideMovieRepository(movieRemoteDataSource: MovieRemoteDataSource): MovieRepository {
         return MovieRepositoryImpl(movieRemoteDataSource)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRecentSearchRepository(recentSearchLocalDataSource: RecentSearchLocalDataSource): RecentSearchRepository {
+        return RecentSearchRepositoryImpl(recentSearchLocalDataSource)
     }
 }

--- a/app/src/main/java/com/ssafy/movie_search/data/model/RecentSearchEntity.kt
+++ b/app/src/main/java/com/ssafy/movie_search/data/model/RecentSearchEntity.kt
@@ -1,0 +1,15 @@
+package com.ssafy.movie_search.data.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.ssafy.movie_search.present.utils.RECENT_SEARCH_TABLE
+
+@Entity(tableName = RECENT_SEARCH_TABLE)
+data class RecentSearchEntity(
+    var keyword: String
+) {
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "Id")
+    var id: Int = 0
+}

--- a/app/src/main/java/com/ssafy/movie_search/data/repository/RecentSearch/RecentSearchLocalDataSource.kt
+++ b/app/src/main/java/com/ssafy/movie_search/data/repository/RecentSearch/RecentSearchLocalDataSource.kt
@@ -1,0 +1,10 @@
+package com.ssafy.movie_search.data.repository.RecentSearch
+
+import androidx.lifecycle.LiveData
+import com.ssafy.movie_search.data.model.RecentSearchEntity
+
+interface RecentSearchLocalDataSource {
+    fun writeRecentSearch(recentSearchEntity: RecentSearchEntity)
+    fun readRecentSearchList(): LiveData<List<RecentSearchEntity>>
+    fun deleteLastItemIfOver10()
+}

--- a/app/src/main/java/com/ssafy/movie_search/data/repository/RecentSearch/RecentSearchLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/ssafy/movie_search/data/repository/RecentSearch/RecentSearchLocalDataSourceImpl.kt
@@ -1,0 +1,22 @@
+package com.ssafy.movie_search.data.repository.RecentSearch
+
+import androidx.lifecycle.LiveData
+import com.ssafy.movie_search.data.db.dao.RecentSearchDao
+import com.ssafy.movie_search.data.model.RecentSearchEntity
+import javax.inject.Inject
+
+class RecentSearchLocalDataSourceImpl @Inject constructor(
+    private val dao: RecentSearchDao
+): RecentSearchLocalDataSource {
+    override fun writeRecentSearch(recentSearchEntity: RecentSearchEntity) {
+        return dao.write(recentSearchEntity)
+    }
+
+    override fun readRecentSearchList(): LiveData<List<RecentSearchEntity>> {
+        return dao.readAll()
+    }
+
+    override fun deleteLastItemIfOver10() {
+        return dao.deleteLastItemIfOver10()
+    }
+}

--- a/app/src/main/java/com/ssafy/movie_search/data/repository/RecentSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/movie_search/data/repository/RecentSearchRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.ssafy.movie_search.data.repository
+
+import androidx.lifecycle.LiveData
+import com.ssafy.movie_search.data.model.RecentSearchEntity
+import com.ssafy.movie_search.data.repository.RecentSearch.RecentSearchLocalDataSource
+import com.ssafy.movie_search.domain.repository.RecentSearchRepository
+import javax.inject.Inject
+
+class RecentSearchRepositoryImpl @Inject constructor(
+    private val recentSearchLocalDataSource: RecentSearchLocalDataSource
+): RecentSearchRepository {
+    override fun writeRecentSearch(recentSearchEntity: RecentSearchEntity) {
+        recentSearchLocalDataSource.deleteLastItemIfOver10()
+        recentSearchLocalDataSource.writeRecentSearch(recentSearchEntity)
+    }
+
+    override fun readRecentSearchList(): LiveData<List<RecentSearchEntity>> {
+        return recentSearchLocalDataSource.readRecentSearchList()
+    }
+}

--- a/app/src/main/java/com/ssafy/movie_search/domain/repository/RecentSearchRepository.kt
+++ b/app/src/main/java/com/ssafy/movie_search/domain/repository/RecentSearchRepository.kt
@@ -1,0 +1,9 @@
+package com.ssafy.movie_search.domain.repository
+
+import androidx.lifecycle.LiveData
+import com.ssafy.movie_search.data.model.RecentSearchEntity
+
+interface RecentSearchRepository {
+    fun writeRecentSearch(recentSearchEntity: RecentSearchEntity)
+    fun readRecentSearchList(): LiveData<List<RecentSearchEntity>>
+}

--- a/app/src/main/java/com/ssafy/movie_search/domain/usecase/recent_search/ReadRecentSearchListUseCase.kt
+++ b/app/src/main/java/com/ssafy/movie_search/domain/usecase/recent_search/ReadRecentSearchListUseCase.kt
@@ -1,0 +1,13 @@
+package com.ssafy.movie_search.domain.usecase.recent_search
+
+import androidx.lifecycle.LiveData
+import com.ssafy.movie_search.data.model.RecentSearchEntity
+import com.ssafy.movie_search.domain.repository.RecentSearchRepository
+import javax.inject.Inject
+
+class ReadRecentSearchListUseCase @Inject constructor(
+    private val recentSearchRepository: RecentSearchRepository
+) {
+    operator fun invoke(): LiveData<List<RecentSearchEntity>>
+        = recentSearchRepository.readRecentSearchList()
+}

--- a/app/src/main/java/com/ssafy/movie_search/domain/usecase/recent_search/WriteRecentSearchUseCase.kt
+++ b/app/src/main/java/com/ssafy/movie_search/domain/usecase/recent_search/WriteRecentSearchUseCase.kt
@@ -1,0 +1,12 @@
+package com.ssafy.movie_search.domain.usecase.recent_search
+
+import com.ssafy.movie_search.data.model.RecentSearchEntity
+import com.ssafy.movie_search.domain.repository.RecentSearchRepository
+import javax.inject.Inject
+
+class WriteRecentSearchUseCase @Inject constructor(
+    private val recentSearchRepository: RecentSearchRepository
+) {
+    operator fun invoke(recentSearchEntity: RecentSearchEntity)
+        = recentSearchRepository.writeRecentSearch(recentSearchEntity)
+}

--- a/app/src/main/java/com/ssafy/movie_search/present/utils/IOConsts.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/utils/IOConsts.kt
@@ -1,0 +1,5 @@
+package com.ssafy.movie_search.present.utils
+
+// room
+const val DB_NAME = "app.db"
+const val RECENT_SEARCH_TABLE = "recent_search_table"

--- a/app/src/main/java/com/ssafy/movie_search/present/views/MovieFragment.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/MovieFragment.kt
@@ -1,20 +1,29 @@
 package com.ssafy.movie_search.present.views
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
 import androidx.core.os.bundleOf
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.andback.pocketfridge.present.config.BaseFragment
 import com.ssafy.movie_search.R
 import com.ssafy.movie_search.databinding.FragmentMovieBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MovieFragment : BaseFragment<FragmentMovieBinding>(R.layout.fragment_movie) {
-    private val viewModel: MovieSharedViewModel by activityViewModels()
+    private val viewModel: MovieViewModel by viewModels()
     lateinit var movieAdapter: MovieAdapter
+    lateinit var mainActivity: MainActivity
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        mainActivity = activity as MainActivity
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -34,7 +43,7 @@ class MovieFragment : BaseFragment<FragmentMovieBinding>(R.layout.fragment_movie
         }
 
         binding.btnMovieFRecentSearch.setOnClickListener {
-            (context as MainActivity).startRecentSearchFragment()
+            mainActivity.startRecentSearchFragment()
         }
     }
 
@@ -52,7 +61,7 @@ class MovieFragment : BaseFragment<FragmentMovieBinding>(R.layout.fragment_movie
         movieAdapter.setItemClickListener(object: MovieAdapter.ItemClickListener{
             override fun onClick(link: String) {
                 setFragmentResult("webLink", bundleOf("webLink" to link))
-                (context as MainActivity).loadWebView()
+                mainActivity.loadWebView()
             }
         })
     }

--- a/app/src/main/java/com/ssafy/movie_search/present/views/MovieViewModel.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/MovieViewModel.kt
@@ -3,17 +3,23 @@ package com.ssafy.movie_search.present.views
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ssafy.movie_search.data.model.RecentSearchEntity
 import com.ssafy.movie_search.domain.model.Movie
 import com.ssafy.movie_search.domain.usecase.GetMovieListUseCase
+import com.ssafy.movie_search.domain.usecase.recent_search.WriteRecentSearchUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class MovieSharedViewModel @Inject constructor(
-    private val getMovieListUseCase: GetMovieListUseCase
+class MovieViewModel @Inject constructor(
+    private val getMovieListUseCase: GetMovieListUseCase,
+    private val writeRecentSearchUseCase: WriteRecentSearchUseCase
 ) : ViewModel() {
     private val compositeDisposable = CompositeDisposable()
 
@@ -44,12 +50,19 @@ class MovieSharedViewModel @Inject constructor(
         )
     }
 
+    fun writeRecentSearch(recentSearchEntity: RecentSearchEntity) {
+        writeRecentSearchUseCase.invoke(recentSearchEntity)
+    }
+
     private fun showError() {
         // TODO: 에러 처리
     }
 
     fun onSearchClick() {
         getMovieList(keyword.value.toString())
+        viewModelScope.launch(Dispatchers.IO) {
+            writeRecentSearch(RecentSearchEntity(keyword.value.toString()))
+        }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/ssafy/movie_search/present/views/RecentSearchFragment.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/RecentSearchFragment.kt
@@ -2,29 +2,36 @@ package com.ssafy.movie_search.present.views
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.viewModels
 import com.andback.pocketfridge.present.config.BaseFragment
 import com.google.android.material.chip.Chip
 import com.ssafy.movie_search.R
 import com.ssafy.movie_search.databinding.FragmentRecentSearchBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class RecentSearchFragment : BaseFragment<FragmentRecentSearchBinding>(R.layout.fragment_recent_search) {
-    var test = 1
+    private val viewModel: RecentSearchViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initEvent()
+        initViewModel()
     }
 
-    private fun initEvent() {
-        binding.btnRecentSearchFTemp.setOnClickListener {
-            binding.cgRecentSearchF.addView(Chip(requireContext()).apply {
-                text = "${test++}번 chip"
+    private fun initViewModel() {
+        with(viewModel) {
+            readRecentSearchList().observe(viewLifecycleOwner) { searchList ->
+                for(i in searchList.lastIndex downTo 0) {
+                    binding.cgRecentSearchF.addView(Chip(requireContext()).apply {
+                        text = "${searchList[i].keyword}"
 
-                setOnClickListener {
-                    showToastMessage("$text")
+                        setOnClickListener {
+                            showToastMessage("$text")
+                        }
+                    })
                 }
-            })
+            }
         }
     }
 }

--- a/app/src/main/java/com/ssafy/movie_search/present/views/RecentSearchViewModel.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/RecentSearchViewModel.kt
@@ -1,0 +1,19 @@
+package com.ssafy.movie_search.present.views
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
+import com.ssafy.movie_search.data.model.RecentSearchEntity
+import com.ssafy.movie_search.domain.usecase.recent_search.ReadRecentSearchListUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class RecentSearchViewModel @Inject constructor(
+    private val readRecentSearchListUseCase: ReadRecentSearchListUseCase
+) : ViewModel() {
+    private val recentSearchList: LiveData<List<RecentSearchEntity>> = readRecentSearchListUseCase.invoke()
+
+    fun readRecentSearchList(): LiveData<List<RecentSearchEntity>> {
+        return recentSearchList
+    }
+}

--- a/app/src/main/res/layout/fragment_movie.xml
+++ b/app/src/main/res/layout/fragment_movie.xml
@@ -6,7 +6,7 @@
     <data>
         <variable
             name="vm"
-            type="com.ssafy.movie_search.present.views.MovieSharedViewModel" />
+            type="com.ssafy.movie_search.present.views.MovieViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_recent_search.xml
+++ b/app/src/main/res/layout/fragment_recent_search.xml
@@ -12,13 +12,6 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <Button
-            android:id="@+id/btn_recent_searchF_temp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="chip 만들기"
-            android:layout_gravity="center"/>
-
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## 개요
- Resolves #10 
- Room을 이용해 DB를 구현했습니다.
- 검색을 하면 DB에 키워드를 저장하도록 했습니다.
- 최근 검색 목록 페이지에서 키워드를 보여주도록 했습니다.
- 최근 검색한 순으로 10개까지 보여주도록 했습니다.

## 구현화면
<img src="https://user-images.githubusercontent.com/76620764/168062986-ff3aa085-8d05-4b67-bf27-56c7ae526928.jpg" height="600"/>