### PR TITLE
feat: 최근 검색 이력을 통한 검색 구현

### DIFF
--- a/app/src/main/java/com/ssafy/movie_search/present/utils/PageSet.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/utils/PageSet.kt
@@ -1,0 +1,7 @@
+package com.ssafy.movie_search.present.utils
+
+enum class PageSet {
+    MOVIE,
+    WEB_VIEW,
+    RECENT_SERACH
+}

--- a/app/src/main/java/com/ssafy/movie_search/present/views/MainActivity.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import com.andback.pocketfridge.present.config.BaseActivity
 import com.ssafy.movie_search.R
 import com.ssafy.movie_search.databinding.ActivityMainBinding
+import com.ssafy.movie_search.present.utils.PageSet
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -23,19 +24,20 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
         }
     }
 
-    fun startRecentSearchFragment() {
-        supportFragmentManager
-            .beginTransaction()
-            .replace(R.id.fl_main, RecentSearchFragment())
-            .addToBackStack(null)
-            .commit()
-    }
-
-    fun loadWebView() {
-        supportFragmentManager
-            .beginTransaction()
-            .replace(R.id.fl_main, WebViewFragment())
-            .addToBackStack(null)
-            .commit()
+    fun onChangeFragement(p: PageSet) {
+        when (p) {
+            PageSet.MOVIE -> supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.fl_main, MovieFragment())
+                .commit()
+            PageSet.WEB_VIEW -> supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.fl_main, WebViewFragment())
+                .commit()
+            PageSet.RECENT_SERACH -> supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.fl_main, RecentSearchFragment())
+                .commit()
+        }
     }
 }

--- a/app/src/main/java/com/ssafy/movie_search/present/views/MovieFragment.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/MovieFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.widget.LinearLayout
 import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -65,5 +66,10 @@ class MovieFragment : BaseFragment<FragmentMovieBinding>(R.layout.fragment_movie
                 mainActivity.onChangeFragement(PageSet.WEB_VIEW)
             }
         })
+
+        setFragmentResultListener("searchedKeyword") { _, bundle ->
+            var searchedKeyword = bundle.getSerializable("searchedKeyword").toString()
+            viewModel.search(searchedKeyword)
+        }
     }
 }

--- a/app/src/main/java/com/ssafy/movie_search/present/views/MovieFragment.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/MovieFragment.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.andback.pocketfridge.present.config.BaseFragment
 import com.ssafy.movie_search.R
 import com.ssafy.movie_search.databinding.FragmentMovieBinding
+import com.ssafy.movie_search.present.utils.PageSet
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -43,7 +44,7 @@ class MovieFragment : BaseFragment<FragmentMovieBinding>(R.layout.fragment_movie
         }
 
         binding.btnMovieFRecentSearch.setOnClickListener {
-            mainActivity.startRecentSearchFragment()
+            mainActivity.onChangeFragement(PageSet.RECENT_SERACH)
         }
     }
 
@@ -61,7 +62,7 @@ class MovieFragment : BaseFragment<FragmentMovieBinding>(R.layout.fragment_movie
         movieAdapter.setItemClickListener(object: MovieAdapter.ItemClickListener{
             override fun onClick(link: String) {
                 setFragmentResult("webLink", bundleOf("webLink" to link))
-                mainActivity.loadWebView()
+                mainActivity.onChangeFragement(PageSet.WEB_VIEW)
             }
         })
     }

--- a/app/src/main/java/com/ssafy/movie_search/present/views/MovieViewModel.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/MovieViewModel.kt
@@ -59,9 +59,13 @@ class MovieViewModel @Inject constructor(
     }
 
     fun onSearchClick() {
-        getMovieList(keyword.value.toString())
+        search(keyword.value.toString())
+    }
+
+    fun search(keyword: String) {
+        getMovieList(keyword)
         viewModelScope.launch(Dispatchers.IO) {
-            writeRecentSearch(RecentSearchEntity(keyword.value.toString()))
+            writeRecentSearch(RecentSearchEntity(keyword))
         }
     }
 

--- a/app/src/main/java/com/ssafy/movie_search/present/views/RecentSearchFragment.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/RecentSearchFragment.kt
@@ -7,11 +7,18 @@ import com.andback.pocketfridge.present.config.BaseFragment
 import com.google.android.material.chip.Chip
 import com.ssafy.movie_search.R
 import com.ssafy.movie_search.databinding.FragmentRecentSearchBinding
+import com.ssafy.movie_search.present.utils.PageSet
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class RecentSearchFragment : BaseFragment<FragmentRecentSearchBinding>(R.layout.fragment_recent_search) {
     private val viewModel: RecentSearchViewModel by viewModels()
+    lateinit var mainActivity: MainActivity
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        mainActivity = activity as MainActivity
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/ssafy/movie_search/present/views/RecentSearchFragment.kt
+++ b/app/src/main/java/com/ssafy/movie_search/present/views/RecentSearchFragment.kt
@@ -1,7 +1,10 @@
 package com.ssafy.movie_search.present.views
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
+import androidx.core.os.bundleOf
+import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import com.andback.pocketfridge.present.config.BaseFragment
 import com.google.android.material.chip.Chip
@@ -34,7 +37,8 @@ class RecentSearchFragment : BaseFragment<FragmentRecentSearchBinding>(R.layout.
                         text = "${searchList[i].keyword}"
 
                         setOnClickListener {
-                            showToastMessage("$text")
+                            setFragmentResult("searchedKeyword", bundleOf("searchedKeyword" to text))
+                            mainActivity.onChangeFragement(PageSet.MOVIE)
                         }
                     })
                 }


### PR DESCRIPTION
## 개요
- Resolves #12
- 최근 검색 이력 목록에서 키워드를 클릭하면 바로 검색이 되도록 구현했습니다.

## 작업사항
- FragmentResultListener를 이용했습니다.
- PageSet을 사용해 페이지 전환 방법을 살짝 변경했습니다.